### PR TITLE
Actually reset all of ctx

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -129,7 +129,7 @@ void md5Final(struct md5Context* ctx, uint8_t digest[16])
 
     byteSwap(ctx->buf, 4);
     memcpy(digest, ctx->buf, 16);
-    memset(ctx, 0, sizeof(ctx)); // In case it's sensitive
+    memset(ctx, 0, sizeof(*ctx)); // In case it's sensitive
 }
 
 // The four core functions - F1 is optimized somewhat


### PR DESCRIPTION
The current version did not reset all of ctx but only one pointer size of it
