### PR TITLE
Use installation as default update location

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -299,6 +299,20 @@ int main(int argc, char* argv[])
     bool nightly = true;
     boost::filesystem::path workPath = argv[0];
     workPath = workPath.parent_path();
+    // If the installation is the default one, update current installation
+#ifdef _WIN32
+    if(boost::filesystem::exists(workPath.parent_path() / "s25client.exe"))
+        workPath = workPath.parent_path();
+#elif defined(__APPLE__)
+    boost::filesystem::path tmpPath = workPath + "/../../../../../..";
+    if(boost::filesystem::exists(tmpPath / "s25client.app/Contents/MacOS/share/s25rttr/RTTR/s25update"))
+        workPath = tmpPath;
+#else
+    boost::filesystem::path tmpPath = workPath + "/../../..";
+    if(boost::filesystem::exists(tmpPath / "share/s25rttr/RTTR/s25update"))
+        workPath = tmpPath;
+#endif
+
 
     if(argc > 1)
     {


### PR DESCRIPTION
This will close https://github.com/Return-To-The-Roots/s25client/issues/434 by trying to use the default installation structure to find the installation path and update to that path.

@Flow86 Please check if this is correct and merge
