### PR TITLE
Handle static CURL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,28 +14,47 @@ endif()
 rttr_set_output_dir(RUNTIME ${RTTR_EXTRA_BINDIR})
 
 add_executable(s25update ${_sources})
-target_include_directories(s25update SYSTEM PRIVATE ${CURL_INCLUDE_DIRS})
-target_link_libraries(s25update PRIVATE s25util::common ${CURL_LIBRARIES} BZip2::BZip2 Boost::filesystem Boost::nowide Boost::disable_autolinking)
+
+if (TARGET CURL::libcurl AND CURL_CONFIG)
+    target_link_libraries(s25update PRIVATE CURL::libcurl)
+    message(STATUS "Found CURL via CMake config")
+else()
+    # Heuristic if CURL is a static library and we need to add the define and some libs
+    if(CURL_LIBRARIES MATCHES "\.a$" OR CURL_LIBRARIES MATCHES "curl_a" OR (WIN32 AND NOT CURL_LIBRARIES MATCHES "_imp\.lib"))
+        message(STATUS "Found static CURL: ${CURL_LIBRARIES}")
+        target_compile_definitions(s25update PRIVATE CURL_STATICLIB)
+        if(MSVC)
+            list(APPEND CURL_LIBRARIES "normaliz.lib;ws2_32.lib;wldap32.lib")
+        endif()
+    else()
+        message(STATUS "Found dynamic CURL: ${CURL_LIBRARIES}")
+    endif()
+    target_include_directories(s25update SYSTEM PRIVATE ${CURL_INCLUDE_DIRS})
+    target_link_libraries(s25update PRIVATE ${CURL_LIBRARIES})
+endif()
+
+target_include_directories(s25update SYSTEM PRIVATE)
+target_link_libraries(s25update PRIVATE s25util::common BZip2::BZip2 Boost::filesystem Boost::nowide Boost::disable_autolinking)
 target_compile_features(s25update PRIVATE cxx_std_17)
 if(NOT PLATFORM_NAME OR NOT PLATFORM_ARCH)
-	message(FATAL_ERROR "PLATFORM_NAME or PLATFORM_ARCH not set")
+    message(FATAL_ERROR "PLATFORM_NAME or PLATFORM_ARCH not set")
 endif()
 target_compile_definitions(s25update PRIVATE "TARGET=\"${PLATFORM_NAME}\"" "ARCH=\"${PLATFORM_ARCH}\"")
 
 if(WIN32)
-	if(MSVC)
-		target_sources(s25update PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../win32/s25update.rc")
-		set_property(TARGET s25update APPEND_STRING PROPERTY LINK_FLAGS " /MANIFEST:NO")
-	else()
-		target_compile_definitions(s25update PRIVATE AFX_TARG_DEU)
-		add_custom_command(
-			OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o
-			COMMAND ${CMAKE_RC_COMPILER} -I${CMAKE_CURRENT_SOURCE_DIR}/../win32/
-				-i${CMAKE_CURRENT_SOURCE_DIR}/../win32/s25update.rc
-				-o ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o
-		)
-		target_sources(s25update PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o)
-	endif()
+    if(MSVC)
+        target_sources(s25update PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../win32/s25update.rc")
+        set_property(TARGET s25update APPEND_STRING PROPERTY LINK_FLAGS " /MANIFEST:NO")
+    else()
+        target_compile_definitions(s25update PRIVATE AFX_TARG_DEU)
+        add_custom_command(
+            OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o
+            COMMAND ${CMAKE_RC_COMPILER} -I${CMAKE_CURRENT_SOURCE_DIR}/../win32/
+                -i${CMAKE_CURRENT_SOURCE_DIR}/../win32/s25update.rc
+                -o ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o
+        )
+        target_sources(s25update PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/s25update.res.o)
+    endif()
 endif()
 
 install(TARGETS s25update RUNTIME DESTINATION ${RTTR_EXTRA_BINDIR})


### PR DESCRIPTION
(Especially) on Windows we need to define `CURL_STATICLIB` when linking to the static curl library or we get errors such as:
> unresolved external symbol __imp__curl_free

Check if the CURL target from the CMake config file (of CURL) was used and trust them to set that define.
Otherwise apply a heuristic to detect whether static CURL was found and set the define (and libs for MSVC) in that case